### PR TITLE
fetch optarch & compiler family in get_gromacs_arch method, take into account that optarch may be a string value + minor style fixes

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -30,6 +30,7 @@ EasyBuild support for building and installing GROMACS, implemented as an easyblo
 @author: Benjamin Roberts (The University of Auckland)
 @author: Luca Marsella (CSCS)
 @author: Guilherme Peretti-Pezzi (CSCS)
+@author: Oliver Stueker (Compute Canada/ACENET)
 """
 import glob
 import os
@@ -70,6 +71,40 @@ class EB_GROMACS(CMakeMake):
         super(EB_GROMACS, self).__init__(*args, **kwargs)
         self.lib_subdir = ''
         self.pre_env = ''
+
+    def get_gromacs_arch(self):
+        """Determine value of GMX_SIMD CMake flag based on optarch string.
+
+        Refs:
+        [0] http://manual.gromacs.org/documentation/2016.3/install-guide/index.html#typical-installation
+        [1] http://manual.gromacs.org/documentation/2016.3/install-guide/index.html#simd-support
+        [2] http://www.gromacs.org/Documentation/Acceleration_and_parallelization
+        """
+        # default: fall back on autodetection
+        res = None
+
+        optarch = build_option('optarch', default='')
+        # take into account that optarch value is a dictionary if it is specified by compiler family
+        if isinstance(optarch, dict):
+            comp_fam = self.toolchain.comp_family()
+            optarch = optarch.get(comp_fam, '').upper()
+
+        if 'AVX2' in optarch and LooseVersion(self.version) >= LooseVersion('5.0'):
+            res = 'AVX2_256'
+        elif 'AVX' in optarch:
+            res = 'AVX_256'
+        elif 'SSE3' in optarch or 'SSE2' in optarch or 'MARCH=NOCONA' in optarch:
+            # Gromacs doesn't have any GMX_SIMD=SSE3 but only SSE2 and SSE4.1 [1].
+            # According to [2] the performance difference between SSE2 and SSE4.1 is minor on x86
+            # and SSE4.1 is not supported by AMD Magny-Cours[1].
+            res = 'SSE2'
+
+        if res:
+            self.log.info("Target architecture based on optarch configuration option ('%s'): %s", optarch, res)
+        else:
+            self.log.info("No target architecture specified based on optarch configuration option ('%s')", optarch)
+
+        return res
 
     def configure_step(self):
         """Custom configuration procedure for GROMACS: set configure options for configure or cmake."""
@@ -124,17 +159,13 @@ class EB_GROMACS(CMakeMake):
             # disable GUI tools
             self.cfg.update('configopts', "-DGMX_X11=OFF")
 
-            # convince to build for an older architecture than present on the build node by setting GMX_SIMD CMake flag.
-            optarch = build_option('optarch', default=None)
-            comp_fam = self.toolchain.comp_family()
-            if isinstance(optarch, dict) and comp_fam in build_option('optarch'):
-                build_arch = optarch[comp_fam]
-                gmx_simd = self.get_gromacs_arch(build_arch)
-                if gmx_simd:
-                    if LooseVersion(self.version) < LooseVersion('5.0'):
-                        self.cfg.update('configopts', "-DGMX_CPU_ACCELERATION=%s" % gmx_simd)
-                    else:
-                        self.cfg.update('configopts', "-DGMX_SIMD=%s" % gmx_simd)
+            # convince to build for an older architecture than present on the build node by setting GMX_SIMD CMake flag
+            gmx_simd = self.get_gromacs_arch()
+            if gmx_simd:
+                if LooseVersion(self.version) < LooseVersion('5.0'):
+                    self.cfg.update('configopts', "-DGMX_CPU_ACCELERATION=%s" % gmx_simd)
+                else:
+                    self.cfg.update('configopts', "-DGMX_SIMD=%s" % gmx_simd)
 
             # set regression test path
             prefix = 'regressiontests'
@@ -370,25 +401,3 @@ class EB_GROMACS(CMakeMake):
             'dirs': dirs,
         }
         super(EB_GROMACS, self).sanity_check_step(custom_paths=custom_paths)
-
-    def get_gromacs_arch(self, build_arch):
-        """Determine value of GMX_SIMD CMake flag based on optarch string.
-
-        Refs:
-        [0] http://manual.gromacs.org/documentation/2016.3/install-guide/index.html#typical-installation
-        [1] http://manual.gromacs.org/documentation/2016.3/install-guide/index.html#simd-support
-        [2] http://www.gromacs.org/Documentation/Acceleration_and_parallelization
-        """
-        build_arch = build_arch.upper()
-        if 'AVX2' in build_arch and LooseVersion(self.version) >= LooseVersion('5.0'):
-            return "AVX2_256"
-        elif 'AVX' in build_arch:
-            return "AVX_256"
-        elif 'SSE3' in build_arch  or  'SSE2' in build_arch  or  'MARCH=NOCONA' in build_arch:
-            # Gromacs doesn't have any GMX_SIMD=SSE3 but only SSE2 and SSE4.1 [1].
-            # According to [2] the performance difference between SSE2 and SSE4.1 is minor on x86
-            # and SSE4.1 is not supported by AMD Magny-Cours[1].
-            return "SSE2"
-        else:
-            # fall back on autodetection
-            return None


### PR DESCRIPTION
style changes & fixes on top of https://github.com/easybuilders/easybuild-easyblocks/pull/1163