### PR TITLE
fix using empty string as fallback value for optarch build option

### DIFF
--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -87,7 +87,8 @@ class EB_GROMACS(CMakeMake):
         # take into account that optarch value is a dictionary if it is specified by compiler family
         if isinstance(optarch, dict):
             comp_fam = self.toolchain.comp_family()
-            optarch = optarch.get(comp_fam, '').upper()
+            optarch = optarch.get(comp_fam, '')
+        optarch = optarch.upper()
 
         if 'AVX512' in optarch and LooseVersion(self.version) >= LooseVersion('2016'):
             res = 'AVX_512'

--- a/easybuild/easyblocks/g/gromacs.py
+++ b/easybuild/easyblocks/g/gromacs.py
@@ -83,7 +83,7 @@ class EB_GROMACS(CMakeMake):
         # default: fall back on autodetection
         res = None
 
-        optarch = build_option('optarch', default='')
+        optarch = build_option('optarch') or ''
         # take into account that optarch value is a dictionary if it is specified by compiler family
         if isinstance(optarch, dict):
             comp_fam = self.toolchain.comp_family()


### PR DESCRIPTION
bug fix for https://github.com/easybuilders/easybuild-easyblocks/pull/1163

@ostueker Without this change, I get the following traceback when `--optarch` is not specified, because the value specified to `default` in `build_option` is only used when the specified build option is not a known build option, while `optarch` is always known, and has `None` as default value...

Seems like @akesandgren's suspicion was right after all. ;-)

```
ERROR: Traceback (most recent call last):
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.5.1.dev0-py2.7.egg/easybuild/main.py", line 128, in bui
ld_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env, hooks=hooks)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.5.1.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2681, i
n build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.5.1.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2597, i
n run_all_steps
    self.run_step(step_name, step_methods)
  File "/prefix/lib/python2.7/site-packages/easybuild_framework-3.5.1.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2472, i
n run_step
    step_method(self)()
  File "/tmp/eb-GTE0IK/included-easyblocks/easybuild/easyblocks/gromacs.py", line 167, in configure_step
    gmx_simd = self.get_gromacs_arch()
  File "/tmp/eb-GTE0IK/included-easyblocks/easybuild/easyblocks/gromacs.py", line 94, in get_gromacs_arch
    if 'AVX512' in optarch and LooseVersion(self.version) >= LooseVersion('2016'):
TypeError: argument of type 'NoneType' is not iterable
```